### PR TITLE
Update to SPM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    
+    steps:
+    - uses: actions/checkout@master
+
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+
+    - name: Install xcpretty
+      run: gem install xcpretty
+
+    - name: Use Xcode 12
+      run: sudo xcode-select -s /Applications/Xcode_12.app
+
+    - name: List available simulators
+      run: xcrun simctl list devices
+
+    - name: Setup simulator
+      id: version
+      run: |
+        CURRENT_SIMULATOR_UUID=$(xcrun simctl create TestDevice com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-0)
+        echo "::set-env name=CURRENT_SIMULATOR_UUID::$CURRENT_SIMULATOR_UUID"
+
+    - name: Test Sample
+      run: ./Scripts/test_sample

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "mobile-buy-sdk-ios"]
-	path = mobile-buy-sdk-ios
-	url = git@github.com:Shopify/mobile-buy-sdk-ios.git
-	branch = release/2020-04-auto-generated

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Shopify
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ![Mobile Buy SDK](https://cloud.githubusercontent.com/assets/5244861/26738020/885c12ac-479a-11e7-8914-2853ec09f89f.png)
 
+![Test](https://github.com/Shopify/mobile-buy-sdk-ios-sample/workflows/Test/badge.svg?event=push)
+[![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg?style=flat)](https://github.com/Shopify/mobile-buy-sdk-ios-sample/blob/master/LICENSE)
+
 # Storefront App
 
 The sample application demonstrates how to build a custom storefront on iOS using [Shopify's mobile buy SDK](https://github.com/Shopify/mobile-buy-sdk-ios). Using this sample application, a user can browse your shop's products and collections, add merchandise to a cart, and then checkout using Apple Pay or a web checkout.
@@ -10,10 +13,14 @@ Note: This sample application is not actively being maintained. Hence, the versi
 
 The sample application is pre-configured with credentials to a test shop and requires no setup to build and run. You can also run the sample application with your own shop by following the steps below:
 
-1. Make sure that you have the **Mobile App** channel installed in your Shopify admin.
-2. From your Shopify admin, navigate to the **Mobile App** channel, and then copy your API key.
-3. Open the Sample Application project in `Storefront.xcodeproj`
-4. Open `Client.swift`, and then insert your API key and shop domain:
+1. Ensure that all submodules of `Buy SDK` have also been updated by running:
+```
+git submodule update --init --recursive
+```
+2. Make sure that you have the **Mobile App** channel installed in your Shopify admin.
+3. From your Shopify admin, navigate to the **Mobile App** channel, and then copy your API key.
+4. Open the Sample Application project in `Storefront.xcodeproj`
+5. Open `Client.swift`, and then insert your API key and shop domain:
 
 ```swift
 final class Client {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Mobile Buy SDK](https://cloud.githubusercontent.com/assets/5244861/26738020/885c12ac-479a-11e7-8914-2853ec09f89f.png)
 
-![Test](https://github.com/Shopify/mobile-buy-sdk-ios-sample/workflows/Test/badge.svg?event=push)
+[![Test](https://github.com/Shopify/mobile-buy-sdk-ios-sample/workflows/Test/badge.svg?event=push)](https://github.com/Shopify/mobile-buy-sdk-ios-sample/actions?query=workflow%3ATest)
 [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg?style=flat)](https://github.com/Shopify/mobile-buy-sdk-ios-sample/blob/master/LICENSE)
 
 # Storefront App

--- a/README.md
+++ b/README.md
@@ -10,14 +10,10 @@ Note: This sample application is not actively being maintained. Hence, the versi
 
 The sample application is pre-configured with credentials to a test shop and requires no setup to build and run. You can also run the sample application with your own shop by following the steps below:
 
-1. Ensure that all submodules of `Buy SDK` have also been updated by running:
-```
-git submodule update --init --recursive
-```
-2. Make sure that you have the **Mobile App** channel installed in your Shopify admin.
-3. From your Shopify admin, navigate to the **Mobile App** channel, and then copy your API key.
-4. Open the Sample Application project in `Storefront.xcodeproj`
-5. Open `Client.swift`, and then insert your API key and shop domain:
+1. Make sure that you have the **Mobile App** channel installed in your Shopify admin.
+2. From your Shopify admin, navigate to the **Mobile App** channel, and then copy your API key.
+3. Open the Sample Application project in `Storefront.xcodeproj`
+4. Open `Client.swift`, and then insert your API key and shop domain:
 
 ```swift
 final class Client {

--- a/Scripts/test_sample
+++ b/Scripts/test_sample
@@ -1,0 +1,11 @@
+ #!/usr/bin/env bash
+
+set -ex
+set -eo pipefail
+
+xcodebuild build \
+-project "Storefront.xcodeproj" \
+-scheme "Storefront" \
+-sdk iphonesimulator \
+-destination "id=$CURRENT_SIMULATOR_UUID" \
+ | xcpretty -c

--- a/Storefront.xcodeproj/project.pbxproj
+++ b/Storefront.xcodeproj/project.pbxproj
@@ -3,12 +3,10 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		810E2563243D1F970025B670 /* Buy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 810E2555243D1E400025B670 /* Buy.framework */; };
-		810E2565243D1FE30025B670 /* Buy.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 810E2555243D1E400025B670 /* Buy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9A0ED6861E83F120008C605E /* Serializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0ED6851E83F120008C605E /* Serializable.swift */; };
 		9A0ED68A1E83FF2D008C605E /* GraphQL+Serializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0ED6891E83FF2D008C605E /* GraphQL+Serializable.swift */; };
 		9A0ED6911E842467008C605E /* CartButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0ED6901E842467008C605E /* CartButton.swift */; };
@@ -23,6 +21,8 @@
 		9A27C32D1E9120AD00218EE8 /* CheckoutViewModel+PayCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A27C32C1E9120AD00218EE8 /* CheckoutViewModel+PayCheckout.swift */; };
 		9A27C32F1E91218100218EE8 /* AddressViewModel+PayAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A27C32E1E91218100218EE8 /* AddressViewModel+PayAddress.swift */; };
 		9A27C3311E91232500218EE8 /* ShippingRateViewModel+PayShippingRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A27C3301E91232500218EE8 /* ShippingRateViewModel+PayShippingRate.swift */; };
+		9A3714DD251B7B3500FE742B /* Pay in Frameworks */ = {isa = PBXBuildFile; productRef = 9A3714DC251B7B3500FE742B /* Pay */; };
+		9A3714DF251B7B3500FE742B /* Buy in Frameworks */ = {isa = PBXBuildFile; productRef = 9A3714DE251B7B3500FE742B /* Buy */; };
 		9A4069D61E8EEDC9000254CD /* ShippingRateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4069D51E8EEDC9000254CD /* ShippingRateViewModel.swift */; };
 		9A4EDDD22126116E0071BA56 /* CustomerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4EDDD12126116E0071BA56 /* CustomerCoordinator.swift */; };
 		9A4EDDD9212611A60071BA56 /* AccountController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4EDDD8212611A60071BA56 /* AccountController.swift */; };
@@ -98,65 +98,6 @@
 		9AFA3B871E6DFF530056C5AA /* SelectableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFA3B861E6DFF530056C5AA /* SelectableCell.swift */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		810E2554243D1E400025B670 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 810E254A243D1E400025B670 /* Buy.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9AEF60F31E5F42D90067FA90;
-			remoteInfo = Buy;
-		};
-		810E2556243D1E400025B670 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 810E254A243D1E400025B670 /* Buy.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9AC2EFC81F6818180037E0D7;
-			remoteInfo = "Buy watchOS";
-		};
-		810E2558243D1E400025B670 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 810E254A243D1E400025B670 /* Buy.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9AF256421F6FEE50005BB0C9;
-			remoteInfo = "Buy tvOS";
-		};
-		810E255A243D1E400025B670 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 810E254A243D1E400025B670 /* Buy.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9A4068DC1E8E7658000254CD;
-			remoteInfo = Pay;
-		};
-		810E255C243D1E400025B670 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 810E254A243D1E400025B670 /* Buy.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9AFA38EA1E64850A0056C5AA;
-			remoteInfo = BuyTests;
-		};
-		810E255E243D1E400025B670 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 810E254A243D1E400025B670 /* Buy.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9A4068E41E8E7659000254CD;
-			remoteInfo = PayTests;
-		};
-		810E2560243D1F7A0025B670 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 810E254A243D1E400025B670 /* Buy.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 9AEF60F21E5F42D90067FA90;
-			remoteInfo = Buy;
-		};
-		810E2566243D206C0025B670 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 810E254A243D1E400025B670 /* Buy.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 9A4068DB1E8E7658000254CD;
-			remoteInfo = Pay;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXCopyFilesBuildPhase section */
 		9AEF61C81E606C800067FA90 /* Copy Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -164,7 +105,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				810E2565243D1FE30025B670 /* Buy.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -172,7 +112,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		810E254A243D1E400025B670 /* Buy.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Buy.xcodeproj; path = "mobile-buy-sdk-ios/Buy.xcodeproj"; sourceTree = "<group>"; };
 		9A0ED6851E83F120008C605E /* Serializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serializable.swift; sourceTree = "<group>"; };
 		9A0ED6891E83FF2D008C605E /* GraphQL+Serializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQL+Serializable.swift"; sourceTree = "<group>"; };
 		9A0ED6901E842467008C605E /* CartButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartButton.swift; sourceTree = "<group>"; };
@@ -270,26 +209,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				810E2563243D1F970025B670 /* Buy.framework in Frameworks */,
+				9A3714DD251B7B3500FE742B /* Pay in Frameworks */,
+				9A3714DF251B7B3500FE742B /* Buy in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		810E254B243D1E400025B670 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				810E2555243D1E400025B670 /* Buy.framework */,
-				810E2557243D1E400025B670 /* Buy.framework */,
-				810E2559243D1E400025B670 /* Buy.framework */,
-				810E255B243D1E400025B670 /* Pay.framework */,
-				810E255D243D1E400025B670 /* BuyTests.xctest */,
-				810E255F243D1E400025B670 /* PayTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		810E2562243D1F970025B670 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -540,7 +467,6 @@
 		9ADAD45E1E563091008AC561 = {
 			isa = PBXGroup;
 			children = (
-				9AEF61BE1E606C5F0067FA90 /* Buy */,
 				9ADAD4691E563091008AC561 /* Storefront */,
 				9ADAD4681E563091008AC561 /* Products */,
 				810E2562243D1F970025B670 /* Frameworks */,
@@ -595,14 +521,6 @@
 			name = Discounts;
 			sourceTree = "<group>";
 		};
-		9AEF61BE1E606C5F0067FA90 /* Buy */ = {
-			isa = PBXGroup;
-			children = (
-				810E254A243D1E400025B670 /* Buy.xcodeproj */,
-			);
-			name = Buy;
-			sourceTree = "<group>";
-		};
 		9AEF61CA1E606EEB0067FA90 /* Fragments */ = {
 			isa = PBXGroup;
 			children = (
@@ -642,10 +560,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				810E2567243D206C0025B670 /* PBXTargetDependency */,
-				810E2561243D1F7A0025B670 /* PBXTargetDependency */,
 			);
 			name = Storefront;
+			packageProductDependencies = (
+				9A3714DC251B7B3500FE742B /* Pay */,
+				9A3714DE251B7B3500FE742B /* Buy */,
+			);
 			productName = Storefront;
 			productReference = 9ADAD4671E563091008AC561 /* Storefront.app */;
 			productType = "com.apple.product-type.application";
@@ -657,7 +577,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = "Shopify Inc.";
 				TargetAttributes = {
 					9ADAD4661E563091008AC561 = {
@@ -682,65 +602,17 @@
 				Base,
 			);
 			mainGroup = 9ADAD45E1E563091008AC561;
+			packageReferences = (
+				9A3714DB251B7B3500FE742B /* XCRemoteSwiftPackageReference "mobile-buy-sdk-ios" */,
+			);
 			productRefGroup = 9ADAD4681E563091008AC561 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 810E254B243D1E400025B670 /* Products */;
-					ProjectRef = 810E254A243D1E400025B670 /* Buy.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				9ADAD4661E563091008AC561 /* Storefront */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		810E2555243D1E400025B670 /* Buy.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Buy.framework;
-			remoteRef = 810E2554243D1E400025B670 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		810E2557243D1E400025B670 /* Buy.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Buy.framework;
-			remoteRef = 810E2556243D1E400025B670 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		810E2559243D1E400025B670 /* Buy.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Buy.framework;
-			remoteRef = 810E2558243D1E400025B670 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		810E255B243D1E400025B670 /* Pay.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Pay.framework;
-			remoteRef = 810E255A243D1E400025B670 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		810E255D243D1E400025B670 /* BuyTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = BuyTests.xctest;
-			remoteRef = 810E255C243D1E400025B670 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		810E255F243D1E400025B670 /* PayTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = PayTests.xctest;
-			remoteRef = 810E255E243D1E400025B670 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		9ADAD4651E563091008AC561 /* Resources */ = {
@@ -849,19 +721,6 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		810E2561243D1F7A0025B670 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Buy;
-			targetProxy = 810E2560243D1F7A0025B670 /* PBXContainerItemProxy */;
-		};
-		810E2567243D206C0025B670 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Pay;
-			targetProxy = 810E2566243D206C0025B670 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin PBXVariantGroup section */
 		9ADAD46E1E563091008AC561 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
@@ -907,6 +766,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -931,7 +791,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -965,6 +825,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -983,10 +844,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -998,7 +860,10 @@
 				CODE_SIGN_ENTITLEMENTS = Storefront/Storefront.entitlements;
 				DEVELOPMENT_TEAM = A7XGC83MZE;
 				INFOPLIST_FILE = Storefront/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.buysdk.storefront;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -1012,7 +877,10 @@
 				CODE_SIGN_ENTITLEMENTS = Storefront/Storefront.entitlements;
 				DEVELOPMENT_TEAM = A7XGC83MZE;
 				INFOPLIST_FILE = Storefront/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.buysdk.storefront;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -1041,6 +909,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9A3714DB251B7B3500FE742B /* XCRemoteSwiftPackageReference "mobile-buy-sdk-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Shopify/mobile-buy-sdk-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9A3714DC251B7B3500FE742B /* Pay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9A3714DB251B7B3500FE742B /* XCRemoteSwiftPackageReference "mobile-buy-sdk-ios" */;
+			productName = Pay;
+		};
+		9A3714DE251B7B3500FE742B /* Buy */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9A3714DB251B7B3500FE742B /* XCRemoteSwiftPackageReference "mobile-buy-sdk-ios" */;
+			productName = Buy;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9ADAD45F1E563091008AC561 /* Project object */;
 }

--- a/Storefront.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Storefront.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/Storefront.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Storefront.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Mobile Buy SDK",
+        "repositoryURL": "https://github.com/Shopify/mobile-buy-sdk-ios",
+        "state": {
+          "branch": null,
+          "revision": "e761f09656c8798cf9e4b3898df7b0f4d960e51a",
+          "version": "5.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Storefront.xcodeproj/project.xcworkspace/xcuserdata/dbart.xcuserdatad/WorkspaceSettings.xcsettings
+++ b/Storefront.xcodeproj/project.xcworkspace/xcuserdata/dbart.xcuserdatad/WorkspaceSettings.xcsettings
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildLocationStyle</key>
+	<string>UseAppPreferences</string>
+	<key>CustomBuildLocationType</key>
+	<string>RelativeToDerivedData</string>
+	<key>DerivedDataLocationStyle</key>
+	<string>Default</string>
+	<key>IssueFilterStyle</key>
+	<string>ShowActiveSchemeOnly</string>
+	<key>LiveSourceIssuesEnabled</key>
+	<true/>
+	<key>ShowSharedSchemesAutomaticallyEnabled</key>
+	<true/>
+</dict>
+</plist>

--- a/Storefront.xcodeproj/xcshareddata/xcschemes/Storefront.xcscheme
+++ b/Storefront.xcodeproj/xcshareddata/xcschemes/Storefront.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Storefront.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:Storefront.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Storefront/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Storefront/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,47 +2,52 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "60x60"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Storefront/ClientQuery.swift
+++ b/Storefront/ClientQuery.swift
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
+import UIKit
 import Buy
 import Pay
 


### PR DESCRIPTION
### What this does

Update the sample app to use Swift Package Manager instead of submodules and Xcode reference. Include other minor update for Xcode 12 and Swift 5.3. Adds a test workflow.