### PR TITLE
Update example project with duties support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       id: version
       run: |
         CURRENT_SIMULATOR_UUID=$(xcrun simctl create TestDevice com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-0)
-        echo "::set-env name=CURRENT_SIMULATOR_UUID::$CURRENT_SIMULATOR_UUID"
+        echo "CURRENT_SIMULATOR_UUID=$CURRENT_SIMULATOR_UUID" >> $GITHUB_ENV
 
     - name: Test Sample
       run: ./Scripts/test_sample

--- a/Storefront.xcodeproj/project.pbxproj
+++ b/Storefront.xcodeproj/project.pbxproj
@@ -915,8 +915,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Shopify/mobile-buy-sdk-ios";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.1.0;
+				branch = "unstable-api-duties-snapshot";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Storefront.xcodeproj/project.pbxproj
+++ b/Storefront.xcodeproj/project.pbxproj
@@ -915,8 +915,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Shopify/mobile-buy-sdk-ios";
 			requirement = {
-				branch = "unstable-api-duties-snapshot";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Storefront.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Storefront.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Mobile Buy SDK",
         "repositoryURL": "https://github.com/Shopify/mobile-buy-sdk-ios",
         "state": {
-          "branch": null,
-          "revision": "e761f09656c8798cf9e4b3898df7b0f4d960e51a",
-          "version": "5.1.0"
+          "branch": "unstable-api-duties-snapshot",
+          "revision": "4b4f63af8d5144b1b29665eff3bb143f8f05db53",
+          "version": null
         }
       }
     ]

--- a/Storefront.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Storefront.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Mobile Buy SDK",
         "repositoryURL": "https://github.com/Shopify/mobile-buy-sdk-ios",
         "state": {
-          "branch": "unstable-api-duties-snapshot",
-          "revision": "4b4f63af8d5144b1b29665eff3bb143f8f05db53",
-          "version": null
+          "branch": null,
+          "revision": "ae783b33100e23b8cd6e61d848d966923e3cc992",
+          "version": "6.0.0"
         }
       }
     ]

--- a/Storefront/CartViewController.swift
+++ b/Storefront/CartViewController.swift
@@ -327,7 +327,7 @@ extension CartViewController: PaySessionDelegate {
             if checkout.ready {
                 provide(checkout.payCheckout)
             } else {
-                Client.shared.fetchUpdatedCheckout(checkout.id) { checkout in
+                Client.shared.pollForReadyCheckout(checkout.id) { checkout in
                     provide(checkout?.payCheckout)
                 }
             }
@@ -344,7 +344,7 @@ extension CartViewController: PaySessionDelegate {
             if updatedCheckout.ready {
                 provide(updatedCheckout.payCheckout)
             } else {
-                Client.shared.fetchUpdatedCheckout(checkout.id) { checkout in
+                Client.shared.pollForReadyCheckout(checkout.id) { checkout in
                     provide(checkout?.payCheckout)
                 }
             }
@@ -375,7 +375,7 @@ extension CartViewController: PaySessionDelegate {
                 
                 print("Checkout email updated: \(email)")
                 
-                Client.shared.fetchUpdatedCheckout(checkout.id) { readyCheckout in
+                Client.shared.pollForReadyCheckout(checkout.id) { readyCheckout in
                     guard let checkout = readyCheckout?.payCheckout else {
                         print("Checkout failed to get ready...")
                         completeTransaction(.failure)

--- a/Storefront/CartViewController.swift
+++ b/Storefront/CartViewController.swift
@@ -318,13 +318,20 @@ extension CartViewController: PaySessionDelegate {
         
         print("Updating checkout with shipping address for tax estimate...")
         Client.shared.updateCheckout(checkout.id, updatingPartialShippingAddress: address) { checkout in
-            
-            if let checkout = checkout {   
-                provide(checkout.payCheckout)
-            } else {
+            guard let checkout = checkout else {
                 print("Update for checkout failed.")
                 provide(nil)
+                return
             }
+
+            if checkout.ready {
+                provide(checkout.payCheckout)
+            } else {
+                Client.shared.fetchUpdatedCheckout(checkout.id) { checkout in
+                    provide(checkout?.payCheckout)
+                }
+            }
+            
         }
     }
     
@@ -333,7 +340,14 @@ extension CartViewController: PaySessionDelegate {
         print("Selecting shipping rate...")
         Client.shared.updateCheckout(checkout.id, updatingShippingRate: shippingRate) { updatedCheckout in
             print("Selected shipping rate.")
-            provide(updatedCheckout?.payCheckout)
+            guard let updatedCheckout = updatedCheckout else { return provide(nil) }
+            if updatedCheckout.ready {
+                provide(updatedCheckout.payCheckout)
+            } else {
+                Client.shared.fetchUpdatedCheckout(checkout.id) { checkout in
+                    provide(checkout?.payCheckout)
+                }
+            }
         }
     }
     
@@ -360,14 +374,24 @@ extension CartViewController: PaySessionDelegate {
                 }
                 
                 print("Checkout email updated: \(email)")
-                print("Completing checkout...")
-                Client.shared.completeCheckout(checkout, billingAddress: authorization.billingAddress, applePayToken: authorization.token, idempotencyToken: paySession.identifier) { payment in
-                    if let payment = payment, checkout.paymentDue == payment.amount {
-                        print("Checkout completed successfully.")
-                        completeTransaction(.success)
-                    } else {
-                        print("Checkout failed to complete.")
+                
+                Client.shared.fetchUpdatedCheckout(checkout.id) { readyCheckout in
+                    guard let checkout = readyCheckout?.payCheckout else {
+                        print("Checkout failed to get ready...")
                         completeTransaction(.failure)
+                        return
+                    }
+                    
+                    print("Checkout is ready...")
+                    print("Completing checkout...")
+                    Client.shared.completeCheckout(checkout, billingAddress: authorization.billingAddress, applePayToken: authorization.token, idempotencyToken: paySession.identifier) { payment in
+                        if let payment = payment, checkout.paymentDue == payment.amount {
+                            print("Checkout completed successfully.")
+                            completeTransaction(.success)
+                        } else {
+                            print("Checkout failed to complete.")
+                            completeTransaction(.failure)
+                        }
                     }
                 }
             }

--- a/Storefront/CheckoutViewModel+PayCheckout.swift
+++ b/Storefront/CheckoutViewModel+PayCheckout.swift
@@ -43,6 +43,7 @@ extension CheckoutViewModel {
             shippingAddress:  self.shippingAddress?.payAddress,
             shippingRate:     self.shippingRate?.payShippingRate,
             currencyCode:     self.currencyCode,
+            totalDuties:      self.totalDuties,
             subtotalPrice:    self.subtotalPrice,
             needsShipping:    self.requiresShipping,
             totalTax:         self.totalTax,

--- a/Storefront/CheckoutViewModel.swift
+++ b/Storefront/CheckoutViewModel.swift
@@ -53,6 +53,7 @@ final class CheckoutViewModel: ViewModel {
     let currencyCode:     String
     let subtotalPrice:    Decimal
     let totalTax:         Decimal
+    let totalDuties:      Decimal?
     let totalPrice:       Decimal
     let paymentDue:       Decimal
     
@@ -86,6 +87,7 @@ final class CheckoutViewModel: ViewModel {
         self.currencyCode     = model.currencyCode.rawValue
         self.subtotalPrice    = model.subtotalPriceV2.amount
         self.totalTax         = model.totalTaxV2.amount
+        self.totalDuties      = model.totalDuties?.amount
         self.totalPrice       = model.totalPriceV2.amount
         self.paymentDue       = model.paymentDueV2.amount
         

--- a/Storefront/Client.swift
+++ b/Storefront/Client.swift
@@ -293,7 +293,8 @@ final class Client {
     }
     
     @discardableResult
-    func fetchUpdatedCheckout(_ id: String, completion: @escaping (CheckoutViewModel?) -> Void) -> Task {
+    func pollForReadyCheckout(_ id: String, completion: @escaping (CheckoutViewModel?) -> Void) -> Task {
+
         let retry = Graph.RetryHandler<Storefront.QueryRoot>(endurance: .finite(30)) { response, error -> Bool in
             error.debugPrint()
             return (response?.node as? Storefront.Checkout)?.ready ?? false == false

--- a/Storefront/ClientQuery.swift
+++ b/Storefront/ClientQuery.swift
@@ -191,6 +191,16 @@ final class ClientQuery {
         }
     }
     
+    static func queryForCheckout(_ id: String) -> Storefront.QueryRootQuery {
+        Storefront.buildQuery { $0
+            .node(id: GraphQL.ID(rawValue: id)) { $0
+                .onCheckout { $0
+                    .fragmentForCheckout()
+                }
+            }
+        }
+    }
+    
     static func mutationForUpdateCheckout(_ id: String, updatingPartialShippingAddress address: PayPostalAddress) -> Storefront.MutationQuery {
         
         let checkoutID   = GraphQL.ID(rawValue: id)

--- a/Storefront/Fragment+CheckoutQuery.swift
+++ b/Storefront/Fragment+CheckoutQuery.swift
@@ -104,6 +104,10 @@ extension Storefront.CheckoutQuery {
                 }
             }
         }
+        .totalDuties { $0
+            .amount()
+            .currencyCode()
+        }
         .webUrl()
         .currencyCode()
         .subtotalPriceV2 { $0

--- a/Storefront/Fragment+OrderConnectionQuery.swift
+++ b/Storefront/Fragment+OrderConnectionQuery.swift
@@ -43,6 +43,14 @@ extension Storefront.OrderConnectionQuery {
                     .amount()
                     .currencyCode()
                 }
+                .originalTotalDuties { $0
+                    .amount()
+                    .currencyCode()
+                }
+                .currentTotalDuties { $0
+                    .amount()
+                    .currencyCode()
+                }
             }
         }
     }

--- a/Storefront/OrderViewModel.swift
+++ b/Storefront/OrderViewModel.swift
@@ -31,25 +31,29 @@ final class OrderViewModel: ViewModel {
     
     typealias ModelType = Storefront.OrderEdge
     
-    let model:       ModelType
-    let cursor:      String
+    let model:                  ModelType
+    let cursor:                 String
     
-    let id:          String
-    let number:      Int
-    let email:       String?
-    let totalPrice:  Decimal
+    let id:                     String
+    let number:                 Int
+    let email:                  String?
+    let currentTotalDuties:     Decimal?
+    let originalTotalDuties:    Decimal?
+    let totalPrice:             Decimal
     
     // ----------------------------------
     //  MARK: - Init -
     //
     required init(from model: ModelType) {
-        self.model       = model
-        self.cursor      = model.cursor
+        self.model               = model
+        self.cursor              = model.cursor
         
-        self.id          = model.node.id.rawValue
-        self.number      = Int(model.node.orderNumber)
-        self.email       = model.node.email
-        self.totalPrice  = model.node.totalPriceV2.amount
+        self.id                  = model.node.id.rawValue
+        self.number              = Int(model.node.orderNumber)
+        self.email               = model.node.email
+        self.currentTotalDuties  = model.node.currentTotalDuties?.amount
+        self.originalTotalDuties = model.node.originalTotalDuties?.amount
+        self.totalPrice          = model.node.totalPriceV2.amount
     }
 }
 


### PR DESCRIPTION
### What's in this PR?

* Add duties to the example project and the Apple Pay payment lines.
* Poll the checkout for readiness after checkout updates to ensure populated duties and taxes fields.
* Update GitHub actions to use GITHUB_ENV instead of set-env.

Also see https://github.com/Shopify/mobile-buy-sdk-ios/pull/1145