### PR TITLE
Add Shop Pay Button example in the cart view controller

### DIFF
--- a/Storefront/Client.swift
+++ b/Storefront/Client.swift
@@ -135,6 +135,25 @@ final class Client {
         return task
     }
     
+    @discardableResult
+    func fetchShopURL(completion: @escaping (URL?) -> Void) -> Task {
+        
+        let query = ClientQuery.queryForShopURL()
+        let task  = self.client.queryGraphWith(query) { (query, error) in
+            error.debugPrint()
+            
+            if let query = query {
+                completion(query.shop.primaryDomain.url)
+            } else {
+                print("Failed to fetch shop url: \(String(describing: error))")
+                completion(nil)
+            }
+        }
+        
+        task.resume()
+        return task
+    }
+    
     // ----------------------------------
     //  MARK: - Collections -
     //

--- a/Storefront/ClientQuery.swift
+++ b/Storefront/ClientQuery.swift
@@ -92,6 +92,16 @@ final class ClientQuery {
         }
     }
     
+    static func queryForShopURL() -> Storefront.QueryRootQuery {
+        return Storefront.buildQuery { $0
+            .shop { $0
+                .primaryDomain { $0
+                    .url()
+                }
+            }
+        }
+    }
+    
     // ----------------------------------
     //  MARK: - Storefront -
     //

--- a/Storefront/TotalsViewController.swift
+++ b/Storefront/TotalsViewController.swift
@@ -31,6 +31,7 @@ import PassKit
 enum PaymentType {
     case applePay
     case webCheckout
+    case shopPay
 }
 
 protocol TotalsControllerDelegate: class {
@@ -75,6 +76,13 @@ class TotalsViewController: UIViewController {
         webCheckout.setTitleColor(.white, for: .normal)
         self.buttonStackView.addArrangedSubview(webCheckout)
         
+        let shopPayCheckout = RoundedButton(type: .system)
+        shopPayCheckout.backgroundColor = UIColor(red: 0.35, green: 0.19, blue: 0.96, alpha: 1.00)
+        shopPayCheckout.addTarget(self, action: #selector(shopPayCheckoutAction(_:)), for: .touchUpInside)
+        shopPayCheckout.setTitle("Shop Pay",  for: .normal)
+        shopPayCheckout.setTitleColor(.white, for: .normal)
+        self.buttonStackView.addArrangedSubview(shopPayCheckout)
+        
         if PKPaymentAuthorizationController.canMakePayments() {
             let applePay = PKPaymentButton(paymentButtonType: .buy, paymentButtonStyle: .black)
             applePay.addTarget(self, action: #selector(applePayAction(_:)), for: .touchUpInside)
@@ -87,6 +95,10 @@ class TotalsViewController: UIViewController {
     //
     @objc func webCheckoutAction(_ sender: Any) {
         self.delegate?.totalsController(self, didRequestPaymentWith: .webCheckout)
+    }
+    
+    @objc func shopPayCheckoutAction(_ sender: Any) {
+        self.delegate?.totalsController(self, didRequestPaymentWith: .shopPay)
     }
     
     @objc func applePayAction(_ sender: Any) {


### PR DESCRIPTION
## What

Using [`Checkout Links powered by Shop Pay`](https://help.shopify.com/en/manual/products/details/checkout-link) functionality, adding an example of how someone might create a Shop Pay button in their iOS app using the mobile buy SDK.

## How

- Added a GraphQL query to get the store's URL.
- Reused functionality that would fetch the product variants for a given set of `CartItems`.
- Constructed a Checkout Link powered by Shop Pay (also called cart permalink) using the variants and quantities. 
- Used the existing `WKWebView` to render the checkout powered by Shop Pay.

## Video


https://user-images.githubusercontent.com/499162/125848321-e70a4598-e15c-42e3-b888-64ed21234d14.mp4


https://user-images.githubusercontent.com/499162/125848322-3825bfe0-9c6a-4fe8-96eb-ea518c194fa4.mp4



